### PR TITLE
Implement basic room selection phase

### DIFF
--- a/22032025/Scenes/RoomSelectionMenu.tscn
+++ b/22032025/Scenes/RoomSelectionMenu.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://Scripts/roomselectionmenu.gd" id="1"]
+
+[node name="RoomSelectionMenu" type="Control"]
+layout_mode = 3
+script = ExtResource("1")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 3
+anchor_left = 0.4
+anchor_top = 0.3
+anchor_right = 0.6
+anchor_bottom = 0.7
+
+[node name="Option1" type="Button" parent="VBoxContainer"]
+text = "Room 1"
+
+[node name="Option2" type="Button" parent="VBoxContainer"]
+text = "Room 2"
+
+[node name="Option3" type="Button" parent="VBoxContainer"]
+text = "Room 3"

--- a/22032025/Scripts/Main.gd
+++ b/22032025/Scripts/Main.gd
@@ -20,6 +20,7 @@ var enemy_ai = null                # Reference to the EnemyAI instanc
 var spell_manager
 var hero = null
 var hero_scene = preload("res://Scenes/Hero.tscn")
+var room_selection_menu
 
 @onready var cooldown_indicator = $SummonCooldownIndicator
 
@@ -141,13 +142,20 @@ func _ready():
 	
 	# 12. Add ScriptDumper
 	var script_dumper_scene = preload("C:/Users/Jacob/Desktop/summoners-guild-0.001/Scripts/script_dumper.gd")
-	var script_dumper = script_dumper_scene.new()
-	add_child(script_dumper)
-	
-	# 13. Start in Phase 1
-	call_deferred("start_in_phase_one")
+        var script_dumper = script_dumper_scene.new()
+        add_child(script_dumper)
 
-	# Add this at the end
+        # 13. Start in Phase 1
+        call_deferred("start_in_phase_one")
+
+        # Load room selection menu but keep it hidden
+        var room_selection_scene = preload("res://Scenes/RoomSelectionMenu.tscn")
+        room_selection_menu = room_selection_scene.instantiate()
+        room_selection_menu.visible = false
+        add_child(room_selection_menu)
+        room_selection_menu.connect("room_chosen", Callable(self, "_on_room_chosen"))
+
+        # Add this at the end
 	call_deferred("diagnose_game_startup")
 
 	## In _ready() or where appropriate
@@ -163,7 +171,7 @@ func start_in_phase_one():
 	_on_phase_changed(GameStateManager.GameState.PHASE1_PREPARATION)
 
 func _on_phase_changed(new_phase):
-	if new_phase == GameStateManager.GameState.PHASE1_PREPARATION:
+        if new_phase == GameStateManager.GameState.PHASE1_PREPARATION:
 		print("PHASE 1: PREPARATION - Draw cards, fusion, and summoning")
 		
 		# Draw player cards up to 6 - ONLY IN PHASE 1
@@ -180,8 +188,22 @@ func _on_phase_changed(new_phase):
 		while enemy_hand.get_hand_size() < 6:
 			enemy_hand.draw_card()
 			enemy_cards_drawn += 1
-	else:
-		print("PHASE 2: COMBAT - No card drawing in this phase")
+       elif new_phase == GameStateManager.GameState.PHASE2_COMBAT:
+               print("PHASE 2: COMBAT - No card drawing in this phase")
+       elif new_phase == GameStateManager.GameState.PHASE3_REWARD:
+               print("PHASE 3: REWARD")
+               # Immediately transition to room selection for now
+               GameStateManager.transition_to_room_selection()
+       elif new_phase == GameStateManager.GameState.PHASE4_ROOM_SELECTION:
+               print("PHASE 4: ROOM SELECTION")
+               room_selection_menu.visible = true
+       else:
+               print("Unknown phase: ", new_phase)
+
+func _on_room_chosen(room_type):
+       print("Room chosen: ", room_type)
+       room_selection_menu.visible = false
+       GameStateManager.transition_to_phase1()
 	
 
 # Add a function to toggle the AI on/off during gameplay

--- a/22032025/Scripts/roomselectionmenu.gd
+++ b/22032025/Scripts/roomselectionmenu.gd
@@ -1,0 +1,11 @@
+extends Control
+
+signal room_chosen(room_type)
+
+func _ready():
+    for button in get_children():
+        if button is Button:
+            button.connect("pressed", Callable(self, "_on_option_pressed").bind(button.name))
+
+func _on_option_pressed(room_type):
+    emit_signal("room_chosen", room_type)


### PR DESCRIPTION
## Summary
- add reward and room selection phases to `GameStateManager`
- load a simple `RoomSelectionMenu` scene
- expose menu from `Main` and show it after combat
- allow choosing a room to restart the preparation phase

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684184f086588323b1fdb4b01cad5ecc